### PR TITLE
ci: depend on the default npm version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ node_js:
   - iojs-v2
   - iojs-v1
   - '0.12'
-before_install:
-  - npm i -g npm@^2.0.0
 before_script:
   - npm prune
 after_success:


### PR DESCRIPTION
remove the forced installation of NPM v2.0.0 in Travis build

closes #39